### PR TITLE
fix: quote dockerfile variable

### DIFF
--- a/build.tmpl.yml
+++ b/build.tmpl.yml
@@ -293,7 +293,7 @@ dockers:
   - image_templates:
       - "oryd/{{ .ProjectName }}:v{{ .Version }}-amd64"
     use: buildx
-    dockerfile: {{.dockerfile}}
+    dockerfile: "{{.dockerfile}}"
     goarch: amd64
     ids:
       - linux-cgo-amd64
@@ -304,7 +304,7 @@ dockers:
       - "oryd/{{ .ProjectName }}:v{{ .Version }}-arm64"
     use: buildx
     goarch: arm64
-    dockerfile: {{.dockerfile}}
+    dockerfile: "{{.dockerfile}}"
     ids:
       - linux-cgo-arm64
     build_flag_templates:
@@ -315,7 +315,7 @@ dockers:
     use: buildx
     goarch: arm
     goarm: 7
-    dockerfile: {{.dockerfile}}
+    dockerfile: "{{.dockerfile}}"
     ids:
       - linux-cgo-arm
     build_flag_templates:
@@ -326,7 +326,7 @@ dockers:
     use: buildx
     goarch: arm
     goarm: 6
-    dockerfile: {{.dockerfile}}
+    dockerfile: "{{.dockerfile}}"
     ids:
       - linux-cgo-arm
     build_flag_templates:


### PR DESCRIPTION
We get `goreleaser check` errors in the Kratos CI: https://app.circleci.com/pipelines/github/ory/kratos/5525/workflows/cb68d4c5-9866-457a-8065-e937eb2bab44/jobs/29094

It seems this was fixed with [goreleaser-pro v1.0.0](https://github.com/goreleaser/goreleaser-pro/releases/tag/v1.0.0-pro), as that release note contains the following point:

> fix(pro): after hooks

and indeed, that (and the most recent v1.1.0) don't produce the same error, but instead:
```
$ /home/patrik/.bin/goreleaser check
   • running goreleaser v1.1.0-pro
   • loading config file       file=.goreleaser.yml
   • importing https://raw.githubusercontent.com/ory/xgoreleaser/master/build.tmpl.yml
   ⨯ command failed            error=failed to load https://raw.githubusercontent.com/ory/xgoreleaser/master/build.tmpl.yml: failed to load config: yaml: unmarshal errors:
  line 296: cannot unmarshal !!map into string
  line 307: cannot unmarshal !!map into string
  line 318: cannot unmarshal !!map into string
  line 329: cannot unmarshal !!map into string
```
which this PR fixes.

To completely make the CI pass again, we will have to also bump the goreleaser version to at least v1.0.0 in Kratos (and the other projects).