### PR TITLE
feat: perform a docker login if env vars exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,8 +142,11 @@ RUN curl -O https://musl.cc/arm-linux-musleabihf-cross.tgz \
 
 ENV PATH=/aarch64-linux-musl-cross/bin:/arm-linux-musleabihf-cross/bin:$PATH
 
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 VOLUME /project
 WORKDIR /project
 
-ENTRYPOINT ["goreleaser"]
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["-v"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [ -n $DOCKER_USERNAME ] && [ -n $DOCKER_PASSWORD ]; then
+    ecoh "Logging in to Docker"
+    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+fi
+
+goreleaser $@


### PR DESCRIPTION
If `DOCKER_USERNAME` and `DOCKER_PASSWORD` exist, we do a `docker login` on
launch.