### PR TITLE
fix: deprecated key in goreleaser template

### DIFF
--- a/build.tmpl.yml
+++ b/build.tmpl.yml
@@ -249,7 +249,7 @@ archives:
       - windows-cgo
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: >-
       {{- .ProjectName }}_
       {{- .Version }}-
@@ -266,7 +266,7 @@ archives:
       - macos-cgo
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: >-
       {{- .ProjectName }}_
       {{- .Version }}-
@@ -285,7 +285,7 @@ archives:
       - linux-cgo-arm
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: >-
       {{- .ProjectName }}_
       {{- .Version }}-
@@ -318,7 +318,7 @@ archives:
       - alpine-cgo-arm
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: >-
       {{- .ProjectName }}_
       {{- .Version }}-
@@ -335,7 +335,7 @@ archives:
       - default
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: >-
       {{- .ProjectName }}_
       {{- .Version }}-


### PR DESCRIPTION
Before this change, goreleaser fails with this error:
```
$ goreleaser check                                                                
  • by using this software you agree with its EULA, available at https://goreleaser.com/eula
  • running goreleaser v2.7.0
    • importing https://raw.githubusercontent.com/ory/xgoreleaser/master/build.tmpl.yml
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
  • DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
  • DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
  • DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
  • DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```