### PR TITLE
fix: ignore broken windows-arm target

### DIFF
--- a/build.tmpl.yml
+++ b/build.tmpl.yml
@@ -238,6 +238,9 @@ builds:
       - darwin
       # Disabled because build will time out, it works though:
       # - freebsd
+    ignore:
+      - goos: windows
+        goarch: arm
     hooks:
       post:
         - cmd: cyclonedx-gomod app -licenses -json -output "./dist/{{ .ProjectName }}_{{ .Version }}_sqlite_{{ .Target }}.bom.json"


### PR DESCRIPTION
goreleaser complains about this, see also https://github.com/golang/go/issues/71671