### PR TITLE
chore: update golang and goreleaser

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
           docker buildx create --use
           go_version="${{ github.event.inputs.golang }}"
           goreleaser_version="${{ github.event.inputs.goreleaser }}"
-          docker buildx build \
+          docker buildx build --push \
             --build-arg GO_VERSION=${go_version} --build-arg GORELEASER_VERSION=${goreleaser_version} \
             --platform linux/amd64 \
             -t oryd/xgoreleaser:${go_version}-${goreleaser_version} \

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,5 @@
 name: Docker
+run-name: Docker - golang ${{ inputs.golang }} - goreleaser ${{ inputs.goreleaser }}
 
 on: 
   workflow_dispatch:
@@ -32,7 +33,7 @@ jobs:
           docker buildx create --use
           go_version="${{ github.event.inputs.golang }}"
           goreleaser_version="${{ github.event.inputs.goreleaser }}"
-          docker buildx build --push \
+          docker buildx build \
             --build-arg GO_VERSION=${go_version} --build-arg GORELEASER_VERSION=${goreleaser_version} \
             --platform linux/amd64 \
             -t oryd/xgoreleaser:${go_version}-${goreleaser_version} \

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ARG LIBTOOL_VERSION=2.4.6_4
 ARG LIBTOOL_SHA=dfb94265706b7204b346e3e5d48e149d7c7870063740f0c4ab2d6ec971260517
 ARG OSX_CODENAME=big_sur
 
-FROM golang:${GO_VERSION}-bullseye AS base
+FROM golang:${GO_VERSION}-bookworm AS base
 ARG APT_MIRROR
 RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
  && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list
@@ -99,18 +99,12 @@ RUN apt-get install -y --no-install-recommends \
     nodejs \
     build-essential \
     docker-ce docker-ce-cli containerd.io \
-    gcc cpp gcc-9 binutils
+    gcc cpp gcc-9 binutils \
+    musl-tools \
 RUN apt-get update -y
 RUN apt-get install -y \
     gcc-aarch64-linux-gnu \
     gcc-arm-linux-gnueabihf
-RUN rm -rf /var/lib/apt/lists/*
-
-# Install libusl with arm support which is only available on "bookworm"
-RUN echo "deb http://ftp.us.debian.org/debian bookworm main" >> /etc/apt/sources.list
-RUN apt-get update -y
-RUN apt-get install -y \
-  musl-tools
 RUN rm -rf /var/lib/apt/lists/*
 
 ARG GORELEASER_VERSION=2.3.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,13 +127,11 @@ COPY --from=osx-cross "${OSX_CROSS_PATH}/." "${OSX_CROSS_PATH}/"
 COPY --from=libtool   "${OSX_CROSS_PATH}/." "${OSX_CROSS_PATH}/"
 ENV PATH=${OSX_CROSS_PATH}/target/bin:$PATH
 
-RUN curl -fL --retry 5 --retry-all-errors --retry-delay 5 \
-         --connect-timeout 10 --max-time 300 \
-         -O https://musl.cc/aarch64-linux-musl-cross.tgz \
+RUN curl -O https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/aarch64-linux-musl-cross.tgz \
     && tar xzf aarch64-linux-musl-cross.tgz \
     && mv aarch64-linux-musl-cross /aarch64-linux-musl-cross
 
-RUN curl -O https://musl.cc/arm-linux-musleabihf-cross.tgz \
+RUN curl -O https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/arm-linux-musleabihf-cross.tgz \
     && tar xzf arm-linux-musleabihf-cross.tgz \
     && mv arm-linux-musleabihf-cross /arm-linux-musleabihf-cross
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,10 +128,12 @@ COPY --from=libtool   "${OSX_CROSS_PATH}/." "${OSX_CROSS_PATH}/"
 ENV PATH=${OSX_CROSS_PATH}/target/bin:$PATH
 
 RUN curl -O https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/aarch64-linux-musl-cross.tgz \
+    && sha512 -c 8695ff86979cdf30fbbcd33061711f5b1ebc3c48a87822b9ca56cde6d3a22abd4dab30fdcd1789ac27c6febbaeb9e5bde59d79d66552fae53d54cc1377a19272 aarch64-linux-musl-cross.tgz \
     && tar xzf aarch64-linux-musl-cross.tgz \
     && mv aarch64-linux-musl-cross /aarch64-linux-musl-cross
 
 RUN curl -O https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/arm-linux-musleabihf-cross.tgz \
+    && sha512 -c fe006d9176cedb453fd817f892f61f6bac273c15879f9c537e22c75b8da4995991211f6d23b0c0c97a87121fe55cf9f9f29cc3d1cf9376804535f07b6c017729 arm-linux-musleabihf-cross.tgz \
     && tar xzf arm-linux-musleabihf-cross.tgz \
     && mv arm-linux-musleabihf-cross /arm-linux-musleabihf-cross
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,8 +96,8 @@ RUN apt-get install -y --no-install-recommends \
     nodejs \
     build-essential \
     docker-ce docker-ce-cli containerd.io \
-    gcc cpp gcc-9 binutils \
-    musl-tools \
+    gcc cpp binutils \
+    musl-tools
 RUN apt-get update -y
 RUN apt-get install -y \
     gcc-aarch64-linux-gnu \
@@ -112,7 +112,7 @@ RUN curl -LO https://github.com/goreleaser/goreleaser/releases/download/v${GOREL
     && mv goreleaser_Linux_x86_64/goreleaser /usr/local/bin/goreleaser-oss \
     && rm -rf goreleaser_Linux_x86_64.* goreleaser_Linux_x86_64/
 
-RUN curl -Lo "goreleaser-pro_Linux_x86_64.tar.gz" "https://github.com/goreleaser/goreleaser-pro/releases/download/v${GORELEASER_VERSION}-pro/goreleaser-pro_Linux_x86_64.tar.gz" \
+RUN curl -Lo "goreleaser-pro_Linux_x86_64.tar.gz" "https://github.com/goreleaser/goreleaser-pro/releases/download/v${GORELEASER_VERSION}/goreleaser-pro_Linux_x86_64.tar.gz" \
     && mkdir -p goreleaser-pro_Linux_x86_64 \
     && tar -xvf goreleaser-pro_Linux_x86_64.tar.gz -C goreleaser-pro_Linux_x86_64 \
     && mv goreleaser-pro_Linux_x86_64/goreleaser /usr/local/bin/goreleaser \

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,16 +127,18 @@ COPY --from=osx-cross "${OSX_CROSS_PATH}/." "${OSX_CROSS_PATH}/"
 COPY --from=libtool   "${OSX_CROSS_PATH}/." "${OSX_CROSS_PATH}/"
 ENV PATH=${OSX_CROSS_PATH}/target/bin:$PATH
 
-#    && sha512 -c 8695ff86979cdf30fbbcd33061711f5b1ebc3c48a87822b9ca56cde6d3a22abd4dab30fdcd1789ac27c6febbaeb9e5bde59d79d66552fae53d54cc1377a19272 aarch64-linux-musl-cross.tgz \
-
+ENV AARCH64SUM=8695ff86979cdf30fbbcd33061711f5b1ebc3c48a87822b9ca56cde6d3a22abd4dab30fdcd1789ac27c6febbaeb9e5bde59d79d66552fae53d54cc1377a19272
+ENV ARMSUM=fe006d9176cedb453fd817f892f61f6bac273c15879f9c537e22c75b8da4995991211f6d23b0c0c97a87121fe55cf9f9f29cc3d1cf9376804535f07b6c017729
 
 RUN curl -LO https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/aarch64-linux-musl-cross.tgz \
+    && echo "$AARCH64SUM  aarch64-linux-musl-cross.tgz" > aarch64.sum \
+    && sha512sum -c aarch64.sum \
     && tar xzf aarch64-linux-musl-cross.tgz \
     && mv aarch64-linux-musl-cross /aarch64-linux-musl-cross
 
-#    && sha512 -c fe006d9176cedb453fd817f892f61f6bac273c15879f9c537e22c75b8da4995991211f6d23b0c0c97a87121fe55cf9f9f29cc3d1cf9376804535f07b6c017729 arm-linux-musleabihf-cross.tgz \
-
 RUN curl -LO https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/arm-linux-musleabihf-cross.tgz \
+    && echo "$ARMSUM  arm-linux-musleabihf-cross.tgz" > arm.sum \
+    && sha512sum -c arm.sum \
     && tar xzf arm-linux-musleabihf-cross.tgz \
     && mv arm-linux-musleabihf-cross /arm-linux-musleabihf-cross
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,13 +127,16 @@ COPY --from=osx-cross "${OSX_CROSS_PATH}/." "${OSX_CROSS_PATH}/"
 COPY --from=libtool   "${OSX_CROSS_PATH}/." "${OSX_CROSS_PATH}/"
 ENV PATH=${OSX_CROSS_PATH}/target/bin:$PATH
 
+#    && sha512 -c 8695ff86979cdf30fbbcd33061711f5b1ebc3c48a87822b9ca56cde6d3a22abd4dab30fdcd1789ac27c6febbaeb9e5bde59d79d66552fae53d54cc1377a19272 aarch64-linux-musl-cross.tgz \
+
+
 RUN curl -O https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/aarch64-linux-musl-cross.tgz \
-    && sha512 -c 8695ff86979cdf30fbbcd33061711f5b1ebc3c48a87822b9ca56cde6d3a22abd4dab30fdcd1789ac27c6febbaeb9e5bde59d79d66552fae53d54cc1377a19272 aarch64-linux-musl-cross.tgz \
     && tar xzf aarch64-linux-musl-cross.tgz \
     && mv aarch64-linux-musl-cross /aarch64-linux-musl-cross
 
+#    && sha512 -c fe006d9176cedb453fd817f892f61f6bac273c15879f9c537e22c75b8da4995991211f6d23b0c0c97a87121fe55cf9f9f29cc3d1cf9376804535f07b6c017729 arm-linux-musleabihf-cross.tgz \
+
 RUN curl -O https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/arm-linux-musleabihf-cross.tgz \
-    && sha512 -c fe006d9176cedb453fd817f892f61f6bac273c15879f9c537e22c75b8da4995991211f6d23b0c0c97a87121fe55cf9f9f29cc3d1cf9376804535f07b6c017729 arm-linux-musleabihf-cross.tgz \
     && tar xzf arm-linux-musleabihf-cross.tgz \
     && mv arm-linux-musleabihf-cross /arm-linux-musleabihf-cross
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,13 +130,13 @@ ENV PATH=${OSX_CROSS_PATH}/target/bin:$PATH
 #    && sha512 -c 8695ff86979cdf30fbbcd33061711f5b1ebc3c48a87822b9ca56cde6d3a22abd4dab30fdcd1789ac27c6febbaeb9e5bde59d79d66552fae53d54cc1377a19272 aarch64-linux-musl-cross.tgz \
 
 
-RUN curl -O https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/aarch64-linux-musl-cross.tgz \
+RUN curl -LO https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/aarch64-linux-musl-cross.tgz \
     && tar xzf aarch64-linux-musl-cross.tgz \
     && mv aarch64-linux-musl-cross /aarch64-linux-musl-cross
 
 #    && sha512 -c fe006d9176cedb453fd817f892f61f6bac273c15879f9c537e22c75b8da4995991211f6d23b0c0c97a87121fe55cf9f9f29cc3d1cf9376804535f07b6c017729 arm-linux-musleabihf-cross.tgz \
 
-RUN curl -O https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/arm-linux-musleabihf-cross.tgz \
+RUN curl -LO https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/arm-linux-musleabihf-cross.tgz \
     && tar xzf arm-linux-musleabihf-cross.tgz \
     && mv arm-linux-musleabihf-cross /arm-linux-musleabihf-cross
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,6 @@ ARG LIBTOOL_SHA=dfb94265706b7204b346e3e5d48e149d7c7870063740f0c4ab2d6ec971260517
 ARG OSX_CODENAME=big_sur
 
 FROM golang:${GO_VERSION}-bookworm AS base
-ARG APT_MIRROR
-RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
- && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list
 ENV OSX_CROSS_PATH=/osxcross
 
 FROM base AS osx-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,9 @@ COPY --from=osx-cross "${OSX_CROSS_PATH}/." "${OSX_CROSS_PATH}/"
 COPY --from=libtool   "${OSX_CROSS_PATH}/." "${OSX_CROSS_PATH}/"
 ENV PATH=${OSX_CROSS_PATH}/target/bin:$PATH
 
-RUN curl -O https://musl.cc/aarch64-linux-musl-cross.tgz \
+RUN curl -fL --retry 5 --retry-all-errors --retry-delay 5 \
+         --connect-timeout 10 --max-time 300 \
+         -O https://musl.cc/aarch64-linux-musl-cross.tgz \
     && tar xzf aarch64-linux-musl-cross.tgz \
     && mv aarch64-linux-musl-cross /aarch64-linux-musl-cross
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.22
+ARG GO_VERSION=1.25.2
 
 # OS-X SDK parameters
 # NOTE: when changing version here, make sure to also change OSX_CODENAME below to match
@@ -104,7 +104,7 @@ RUN apt-get install -y \
     gcc-arm-linux-gnueabihf
 RUN rm -rf /var/lib/apt/lists/*
 
-ARG GORELEASER_VERSION=2.3.2
+ARG GORELEASER_VERSION=2.12.5
 
 RUN curl -LO https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz \
     && mkdir -p goreleaser_Linux_x86_64 \

--- a/test/.docker/Dockerfile-goreleaser
+++ b/test/.docker/Dockerfile-goreleaser
@@ -11,11 +11,11 @@ ENV DOCKER_SHORT_TAG=v0.0.0-alpha.1
 ADD . /home/ory/
 
 ENTRYPOINT ["goreleaser"]
-CMD ["--snapshot", "--skip-publish", "--skip-sign", "--rm-dist"]
+CMD ["--snapshot", "--skip=publish,sign", "--clean"]
 
 # Manual for debugging:
 #   docker rm -f build || true; docker build -f .docker/Dockerfile-goreleaser -t build .; docker run build
 #
 # or:
 #   docker rm -f build || true; docker build -f .docker/Dockerfile-goreleaser -t build .; docker run --cpus 6 --name build --entrypoint /bin/bash -it build
-#   goreleaser --snapshot --skip-publish --rm-dist
+#   goreleaser --snapshot --skip=publish,sign --clean


### PR DESCRIPTION
Updates:
- golang version to 1.25.2
- goreleaser version to 2.12.5
- base image from bullseye to bookwork (because bullseye is too old for golang 1.25)

According to https://musl.cc/:
> 2025-05-27: GitHub Actions has been blocked wholesale due to [abuse similar to this](https://github.com/orgs/community/discussions/27906#discussioncomment-3332440).

so I had to use a mirror